### PR TITLE
Add reloads collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,6 @@ Flags:
   * `logstash_process_process_time_seconds` Was the total process time.
   * `logstash_process_total_virtual_memory_bytes` Was the used virtual memory.
   * `logstash_status` Was the logstash status: 0 for Green; 1 for Yellow; 2 for Red.
-  
+* reloads metrics
+  * `logstash_reloads_config_failures_total` Number of failures during config reload
+  * `logstash_reloads_config_successes_total` Number of successful config reloads

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -38,6 +38,7 @@ type Collector struct {
 	jvm            *jvmCollector
 	process        *processCollector
 	pipelineConfig *pipelineConfigCollector
+	reloadsConfig  *reloadsConfigCollector
 	event          *eventCollector
 	pipeline       *pipelinesCollector
 }
@@ -87,6 +88,7 @@ func NewCollector(uri string, timeout time.Duration) (*Collector, error) {
 		jvm:            newJVMCollector(),
 		process:        newProcessCollector(),
 		pipelineConfig: newPipelineConfigCollector(),
+		reloadsConfig:  newReloadsConfigCollector(),
 		event:          newEventCollector(),
 		pipeline:       newPipelinesCollector(),
 	}, nil
@@ -142,6 +144,7 @@ func (c *Collector) scrape(ch chan<- prometheus.Metric) (up float64) {
 	c.jvm.Collect(stats.JVM, ch)
 	c.process.Collect(stats.Process, ch)
 	c.pipelineConfig.Collect(stats.Pipeline, ch)
+	c.reloadsConfig.Collect(stats.Reloads, ch)
 	c.event.Collect(stats.Event, ch)
 	c.pipeline.Collect(stats.Pipelines, ch)
 

--- a/collector/model.go
+++ b/collector/model.go
@@ -11,6 +11,7 @@ type NodeStats struct {
 	Status      string `json:"status"`
 
 	Pipeline  PipelineConfig      `json:"pipeline"`
+	Reloads   ReloadsConfig       `json:"reloads"`
 	JVM       JVM                 `json:"jvm"`
 	Process   Process             `json:"process"`
 	Event     Event               `json:"events"`
@@ -21,6 +22,11 @@ type PipelineConfig struct {
 	Workers    int `json:"workers"`
 	BatchSize  int `json:"batch_size"`
 	BatchDelay int `json:"batch_delay"`
+}
+
+type ReloadsConfig struct {
+	Failures  int `json:"failures"`
+	Successes int `json:"successes"`
 }
 
 type Process struct {

--- a/collector/reloads_config.go
+++ b/collector/reloads_config.go
@@ -1,0 +1,21 @@
+package collector
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type reloadsConfigCollector struct {
+	Failures  *prometheus.Desc
+	Successes *prometheus.Desc
+}
+
+func newReloadsConfigCollector() *reloadsConfigCollector {
+	desc := newDescFunc(namespace, "reloads_config")
+	return &reloadsConfigCollector{
+		Failures:  desc("failures_total", "Number of failures during config reload."),
+		Successes: desc("successes_total", "Number of successful config reloads."),
+	}
+}
+
+func (c *reloadsConfigCollector) Collect(p ReloadsConfig, ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(c.Failures, prometheus.CounterValue, float64(p.Failures))
+	ch <- prometheus.MustNewConstMetric(c.Successes, prometheus.CounterValue, float64(p.Successes))
+}

--- a/collector/testdata/stats.json
+++ b/collector/testdata/stats.json
@@ -240,8 +240,8 @@
     }
   },
   "reloads": {
-    "failures": 0,
-    "successes": 0
+    "failures": 1,
+    "successes": 3
   },
   "os": {
     "cgroup": {


### PR DESCRIPTION
This PR adds a `reloadsCollector` which is supposed to collect `reloads` from logstash node api, which contains a number of successful and failed configuration reload attempts.